### PR TITLE
oTree liveliness monitor

### DIFF
--- a/encode-token.js
+++ b/encode-token.js
@@ -21,7 +21,7 @@ function clone(o) {
   return JSON.parse(JSON.stringify(o))
 }
 
-const users = ['user001', 'user002', 'user003', 'user004', 'user005']
+const users = ['user001', 'user002', 'user003', 'user004', 'user005', 'user006']
 
 const userTokens = users.map(u => {
   const userData = clone(userTemplate)

--- a/schedulers/gat-scheduler.js
+++ b/schedulers/gat-scheduler.js
@@ -24,22 +24,77 @@ class GatScheduler {
     this.queue.push(user)
   }
 
-  checkConditionAndReturnUsers() {
-    const queueSize = this.queue.size()
-    if (queueSize >= this.min) {
-      // How many to pop? min or max?
-      // const noToPop = Math.min(queueSize, this.max) 
-      return {
-        condition: true,
-        users: this.queue.pop(this.min),
-        waitForCount: 0
+  playersToWaitFor() {
+    return Math.max(0, this.min - this.queue.size())
+  }
+
+  signalUsers() {
+    const playersToWaitFor = this.playersToWaitFor()
+    this.queue.getQueue().forEach(user => {
+      if (!user) {
+        console.error(`User ${userId} not found!`)
+        return
       }
-    }
-    return {
+      const sock = user.webSocket
+      if (!sock) {
+        console.error(`Socket for ${userId} not found!`)
+        return
+      }
+      sock.emit('queueUpdate',{
+        playersToWaitFor: playersToWaitFor,
+        maxPlayers: this.min
+      })
+    })
+  }
+
+  checkConditionAndReturnUsers(experiments, usedUrls) {
+    const queueSize = this.queue.size()
+    const falseCondition = {
       condition: false,
       users: this.queue.getQueue().slice(0, this.min),
-      waitForCount: this.min - queueSize
+      waitForCount: Math.max(0, this.min - queueSize),
+      server: null
     }
+    if (queueSize < this.min || !(experiments && experiments[this.experimentName] && experiments[this.experimentName].servers)) {
+      return falseCondition
+    }
+
+    for (const [serverIp, serverUrls] of Object.entries(experiments[this.experimentName].servers)) {
+      if (serverUrls.length < this.min) {
+        continue
+      }
+
+      let unusedUrlsCount = 0;
+      for (let serverUrl of serverUrls) {
+        if (!usedUrls.has(serverUrl)) {
+          unusedUrlsCount += 1
+        }
+      }
+      if (unusedUrlsCount < this.min) {
+        continue
+      }
+
+      const users = this.queue.pop(this.min)
+      for (const user of users) {
+        while (true) {
+          const url = serverUrls.pop()
+          if (!usedUrls.has(url)) {
+            user.redirectedUrl = url
+            usedUrls.add(url)
+            break
+          }
+          serverUrls.unshift(url)
+        }
+      }
+      return {
+        condition: true,
+        users: users,
+        waitForCount: 0,
+        server: serverIp
+      }
+    }
+
+    return falseCondition
   }
 }
 

--- a/schedulers/gat-scheduler.js
+++ b/schedulers/gat-scheduler.js
@@ -28,6 +28,10 @@ class GatScheduler {
     return Math.max(0, this.min - this.queue.size())
   }
 
+  minPlayersNeeded() {
+    return this.min
+  }
+
   signalUsers() {
     const playersToWaitFor = this.playersToWaitFor()
     this.queue.getQueue().forEach(user => {

--- a/server.js
+++ b/server.js
@@ -158,7 +158,7 @@ async function getExperimentUrls(experiments) {
   const expToEnable = config.experiments.map(e => e.name)
 
   // clear existing URLs first:
-  for (const [name, val] of Object.entries(experiments)) {
+  for (const [_, val] of Object.entries(experiments)) {
     // console.log(JSON.stringify(val, null, 4))
     for (const [_, arr] of Object.entries(val.servers)) {
       arr.splice(0, arr.length)
@@ -250,8 +250,6 @@ function startReadyGames(experiments, agreementIds, usersDb) {
 }
 
 async function main() {
-  // TODO: matchUsers should be part of the experiments object per experiment
-  const matchUsers = 3
   const experiments = {}
   /**
    *
@@ -480,7 +478,7 @@ async function main() {
 
         user.webSocket.emit("wait", {
           playersToWaitFor: scheduler.playersToWaitFor(),
-          maxPlayers: matchUsers
+          maxPlayers: scheduler.minPlayersNeeded()
         })
         scheduler.signalUsers()
       })//addListenerForState

--- a/test/gat-scheduler-test.js
+++ b/test/gat-scheduler-test.js
@@ -4,9 +4,25 @@ const LocalQueue = require("../local-queue")
 const Scheduler = require("../schedulers/gat-scheduler.js")().class
 const User = require("../user.js");
 
-test("test GAT scheduler", () => {
+test("test GAT scheduler with enough rooms", () => {
   const experimentName = "exp001"
-  const scheduler = new Scheduler(experimentName, LocalQueue, {min:3, max:7})
+  const experiments = {
+    exp001: {
+      name: experimentName,
+      servers: {
+        "127.0.0.1": [
+            "http://127.0.0.1/1",
+            "http://127.0.0.1/2",
+            "http://127.0.0.1/3",
+            "http://127.0.0.1/4",
+            "http://127.0.0.1/5",
+            "http://127.0.0.1/6",
+        ]
+      }
+    }
+  }
+  const usedUrls = new Set()
+  const scheduler = new Scheduler(experimentName, LocalQueue, {min:3})
   const users = ['u01', 'u02', 'u03', 'u04', 'u05', 'u06', 'u07'].map(userId => {
     return new User(userId, experimentName)
   })
@@ -15,27 +31,113 @@ test("test GAT scheduler", () => {
   })
   assert.strictEqual(scheduler.queue.size(), 7)
 
-  let conditionObject = scheduler.checkConditionAndReturnUsers()
+  let conditionObject = scheduler.checkConditionAndReturnUsers(experiments, usedUrls)
   assert.strictEqual(conditionObject.condition, true)
   assert.strictEqual(conditionObject.users.length, 3)
   assert.strictEqual(conditionObject.waitForCount, 0)
   
   assert.strictEqual(scheduler.queue.size(), 4)
 
-  conditionObject = scheduler.checkConditionAndReturnUsers()
+  assert.strictEqual(usedUrls.size, 3)
+
+  conditionObject = scheduler.checkConditionAndReturnUsers(experiments, usedUrls)
   assert.strictEqual(conditionObject.condition, true)
   assert.strictEqual(conditionObject.users.length, 3)
   assert.strictEqual(conditionObject.waitForCount, 0)
  
   assert.strictEqual(scheduler.queue.size(), 1)
 
+  assert.strictEqual(usedUrls.size, 6)
+
   const userIds = scheduler.queue.getQueue().map(u => u.userId)
 
   assert.deepStrictEqual(userIds, ['u07'])
   
-  conditionObject = scheduler.checkConditionAndReturnUsers()
+  conditionObject = scheduler.checkConditionAndReturnUsers(experiments)
   assert.strictEqual(conditionObject.condition, false)
   assert.strictEqual(conditionObject.users.length, 1)
   assert.strictEqual(conditionObject.waitForCount, 2)
 
+  assert.strictEqual(usedUrls.size, 6)
+
+});
+
+test("test GAT scheduler without enough rooms", () => {
+  const experimentName = "exp001"
+  const experiments = {
+    exp001: {
+      name: experimentName,
+      servers: {
+        "127.0.0.1": [
+          "http://127.0.0.1/1",
+          "http://127.0.0.1/2",
+          "http://127.0.0.1/3",
+          "http://127.0.0.1/4",
+        ]
+      }
+    }
+  }
+  const usedUrls = new Set()
+  const scheduler = new Scheduler(experimentName, LocalQueue, {min:3})
+  const users = ['u01', 'u02', 'u03', 'u04', 'u05', 'u06', 'u07'].map(userId => {
+    return new User(userId, experimentName)
+  })
+  users.forEach(user => {
+    scheduler.queueUser(user)
+  })
+  assert.strictEqual(scheduler.queue.size(), 7)
+
+  let conditionObject = scheduler.checkConditionAndReturnUsers(experiments, usedUrls)
+  assert.strictEqual(conditionObject.condition, true)
+  assert.strictEqual(conditionObject.users.length, 3)
+  assert.strictEqual(conditionObject.waitForCount, 0)
+
+  assert.strictEqual(scheduler.queue.size(), 4)
+
+  assert.strictEqual(usedUrls.size, 3)
+
+  conditionObject = scheduler.checkConditionAndReturnUsers(experiments, usedUrls)
+  assert.strictEqual(conditionObject.condition, false)
+  assert.strictEqual(conditionObject.users.length, 3)
+  assert.strictEqual(conditionObject.waitForCount, 0)
+
+  assert.strictEqual(scheduler.queue.size(), 4)
+
+  assert.strictEqual(usedUrls.size, 3)
+
+  const userIds = scheduler.queue.getQueue().map(u => u.userId)
+
+  assert.deepStrictEqual(userIds, ['u04', 'u05', 'u06', 'u07'])
+});
+
+test("test GAT scheduler with used URLs", () => {
+  const experimentName = "exp001"
+  const experiments = {
+    exp001: {
+      name: experimentName,
+      servers: {
+        "127.0.0.1": [
+          "http://127.0.0.1/1",
+          "http://127.0.0.1/2",
+          "http://127.0.0.1/3",
+        ]
+      }
+    }
+  }
+  const usedUrls = new Set(["http://127.0.0.1/1"])
+  const scheduler = new Scheduler(experimentName, LocalQueue, {min:3})
+  const users = ['u01', 'u02', 'u03'].map(userId => {
+    return new User(userId, experimentName)
+  })
+  users.forEach(user => {
+    scheduler.queueUser(user)
+  })
+  assert.strictEqual(scheduler.queue.size(), 3)
+
+  let conditionObject = scheduler.checkConditionAndReturnUsers(experiments, usedUrls)
+  assert.strictEqual(conditionObject.condition, false)
+  assert.strictEqual(conditionObject.users.length, 3)
+  assert.strictEqual(conditionObject.waitForCount, 0)
+
+  assert.strictEqual(usedUrls.size, 1)
 });

--- a/webpage_templates/default.html
+++ b/webpage_templates/default.html
@@ -61,7 +61,7 @@
         <div class="w3-center">
 
           <p>Welcome to the waiting room!</p>
-          <p>We are waiting for <span id="playersToWaitFor"></span> more player/s. We can start the game when we have a total of <span id="maxPlayers"></span> players!</p>
+          <p>We are waiting for <span id="playersToWaitFor"></span> more player/s. We can start the game when we have a total of <span id="maxPlayers"></span> players and a room!</p>
 
         </div>
       </div>

--- a/webpage_templates/example_template.html
+++ b/webpage_templates/example_template.html
@@ -85,7 +85,7 @@
           <div class="w3-center">
 
             <p>Welkom in de wachtkamer!</p>
-            <p>We wachten nog op <span id="playersToWaitFor"></span> spelers. Zosnel er in total <span id="maxPlayers"></span> speler/s zijn zal het spel starten.</p>
+            <p>We wachten nog op <span id="playersToWaitFor"></span> speler(s). Zodra er in totaal <span id="maxPlayers"></span> speler(s) zijn en er een kamer beschikbaar is, zal het spel starten.</p>
 
           </div>
         </div>

--- a/webpage_templates/guess_two_thirds.html
+++ b/webpage_templates/guess_two_thirds.html
@@ -85,7 +85,7 @@
           <div class="w3-center">
 
             <p>Welkom in de wachtkamer!</p>
-            <p>We wachten nog op <span id="playersToWaitFor"></span> spelers. Zosnel er in total <span id="maxPlayers"></span> speler/s zijn zal het spel starten.</p>
+            <p>We wachten nog op <span id="playersToWaitFor"></span> speler(s). Zodra er in totaal <span id="maxPlayers"></span> speler(s) zijn en er een kamer beschikbaar is, zal het spel starten.</p>
 
           </div>
         </div>
@@ -170,7 +170,7 @@
       })
     })
 
-    // Server instrcuts us to wait for more players.
+    // Server instructs us to wait for more players.
     // Server passes the number of players we are waiting for.
     socket.on('wait', (data) => {
       console.log('[SOCKET][wait] ', data)


### PR DESCRIPTION
## oTree liveliness monitor

Changes proposed in this pull request:

* Every second, we check if there are enough users in a queue *and* if there is a room available, instead of at startup

How to test:

* Start the otree-docker service, but *without* creating any rooms
* Start the oTree waiting room, open the 6 URLs and enter the waiting room in all 6
* create one room with space for 3
* only 3 of the 6 pages should show the "Gereed" button, click it on all 3, they should be redirected
* create another room of 3
* the other pages should now have the "Gereed" button

Closes #20